### PR TITLE
Fix Dodo DSL quotes

### DIFF
--- a/jenkins-server/jobdsl/dodo.groovy
+++ b/jenkins-server/jobdsl/dodo.groovy
@@ -24,7 +24,7 @@ pipelineJob('wonderland-dodo') {
 
         stage ('Scan and Deploy') {
             steps {
-                sh ''' 
+                sh \'\'\'
                     checkov -d . --check CKV2_AWS_39,CKV2_AWS_38,CKV_AWS_20,CKV_AWS_57
                     terraform init -no-color
                     terraform plan -no-color
@@ -36,7 +36,7 @@ pipelineJob('wonderland-dodo') {
                     else
                         echo "FLAG7: A62F0E52-7D67-410E-8279-32447ADAD916"
                     fi
-                '''
+                \'\'\'
             }
         }
 

--- a/jenkins-server/jobdsl/dodo.groovy
+++ b/jenkins-server/jobdsl/dodo.groovy
@@ -24,7 +24,7 @@ pipelineJob('wonderland-dodo') {
 
         stage ('Scan and Deploy') {
             steps {
-                sh """
+                sh ''' 
                     checkov -d . --check CKV2_AWS_39,CKV2_AWS_38,CKV_AWS_20,CKV_AWS_57
                     terraform init -no-color
                     terraform plan -no-color
@@ -36,7 +36,7 @@ pipelineJob('wonderland-dodo') {
                     else
                         echo "FLAG7: A62F0E52-7D67-410E-8279-32447ADAD916"
                     fi
-                """
+                '''
             }
         }
 


### PR DESCRIPTION
Build for wonderland-dodo is currently broken since multi line `sh` uses `"""` instead of `'''` in the job DSL. Due to this it currently fails to build since Jenkins tries to resolve `$res` and fails to find the variable. This makes challenge Dodo impossible to solve.
This PR fixes this issue by setting the right quotes.