### PR TITLE
fix gitea startup issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ docker-compose up -d
 * No need to hijack admin accounts of Gitea or Jenkins (named "admin" or "red-queen").
 
 ### Take the challenge
-1. Login to CTFd at http://localhost:8000 to view the challenges:
+1. After starting the containers, it might take up to 5 minutes until the containers configuration process is complete.
+2. Login to CTFd at http://localhost:8000 to view the challenges:
    * Username: `alice`
    * Password: `alice`
 
-2. Hack:
+3. Hack:
    * Jenkins http://localhost:8080
      * Username: `alice`
      * Password: `alice`
@@ -85,7 +86,7 @@ docker-compose up -d
      * Username: `thealice`
      * Password: `thealice`
 
-3. Insert the flags on CTFd and find out if you got it right.
+4. Insert the flags on CTFd and find out if you got it right.
 
 ### Troubleshooting
 * If Gitea shows a blank page, refresh the page.

--- a/gitea/run
+++ b/gitea/run
@@ -3,7 +3,7 @@ set -m
 USERNAME=red_queen
 PASSWORD=ciderland5#
 /usr/bin/entrypoint &
-sleep 20
+sleep 40
 su -c "gitea admin user create --username $USERNAME --password $PASSWORD --email queen@localhost --admin" git
 cd /setup
 python3 -m giteacasc /setup/gitea.yaml -u $USERNAME -p $PASSWORD


### PR DESCRIPTION
In some machines with limited resources the server started after the configuration process instead of beforehand.