### PR TITLE
Update requirements.txt - Prevent nest-of-gold test crash

### DIFF
--- a/gitlab/repositories/nest-of-gold/requirements.txt
+++ b/gitlab/repositories/nest-of-gold/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.0
 flask-login==0.6.3
 pytest==7.4.4
+Werkzeug==2.3.3


### PR DESCRIPTION
Currently the nest-of-gold gitlab repositories test cases crash. This is due to it using the latest Werkzeug version instead of a frozen old one.
If Werkzeug version is 3.0+ we get 
```
ImportError: cannot import name 'url_decode' from 'werkzeug.urls'
```
as they have removed all the non-core public APIs v3.0 onwards. The minimum requirement for flask-login is Werkzeug 2.3.3. Hence the same.